### PR TITLE
Fix critical bugs and clean up codebase

### DIFF
--- a/opds.koplugin/main.lua
+++ b/opds.koplugin/main.lua
@@ -17,7 +17,6 @@ local OPDS = WidgetContainer:extend{
     settings = nil,
     servers = nil,
     downloads = nil,
-    -- Add auto-sync task reference
     periodic_sync_task = nil,
     default_servers = {
         {
@@ -45,17 +44,15 @@ local OPDS = WidgetContainer:extend{
             url = "https://gallica.bnf.fr/opds",
         },
     },
-    -- Add default settings with auto-sync enabled
     default_settings = {
         sync_dir = nil,
         sync_max_dl = 50,
         filetypes = nil,
-        -- Auto-sync settings with defaults
-        auto_sync = true,           -- Enabled by default
-        sync_interval_hours = 24,   -- Sync every 24 hours
-        sync_on_network = true,     -- Sync when network connects
-        sync_on_resume = true,      -- Sync when resuming from sleep
-        last_sync_time = 0,         -- Track last sync time
+        auto_sync = true,
+        sync_interval_hours = 24,
+        sync_on_network = true,
+        sync_on_resume = true,
+        last_sync_time = 0,
     },
 }
 
@@ -66,9 +63,7 @@ function OPDS:init()
     end
     self.servers = self.opds_settings:readSetting("servers", self.default_servers)
     self.downloads = self.opds_settings:readSetting("downloads", {})
-    -- Initialize settings with defaults
     self.settings = self.opds_settings:readSetting("settings", self.default_settings)
-    -- Ensure all default settings are present
     for k, v in pairs(self.default_settings) do
         if self.settings[k] == nil then
             self.settings[k] = v
@@ -78,9 +73,7 @@ function OPDS:init()
     self.pending_syncs = self.opds_settings:readSetting("pending_syncs", {})
     self.sync_in_progress = false
 
-    -- Initialize auto-sync
     self:initAutoSync()
-
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
 end
@@ -154,9 +147,9 @@ end
 function OPDS:initAutoSync()
     -- Create periodic sync task
     self.periodic_sync_task = function()
-        logger.info("OPDS: Running periodic sync check")
+        logger.dbg("OPDS: Running periodic sync check")
         self:performAutoSync()
-        self:schedulePeriodicSync() 
+        self:schedulePeriodicSync()
     end
 
     -- Schedule initial sync
@@ -177,7 +170,7 @@ function OPDS:registerAutoSyncEvents()
 end
 
 function OPDS:_onNetworkConnected()
-    logger.info("OPDS: Network connected, checking auto-sync")
+    logger.dbg("OPDS: Network connected, checking auto-sync")
     if self.settings.sync_on_network then
         UIManager:scheduleIn(0.5, function()
             self:performAutoSync()
@@ -186,7 +179,7 @@ function OPDS:_onNetworkConnected()
 end
 
 function OPDS:_onResume()
-    logger.info("OPDS: Resumed, checking auto-sync")
+    logger.dbg("OPDS: Resumed, checking auto-sync")
     if self.settings.sync_on_resume then
         UIManager:scheduleIn(2, function()
             self:performAutoSync()
@@ -198,61 +191,52 @@ function OPDS:schedulePeriodicSync()
     UIManager:unschedule(self.periodic_sync_task)
     local interval_seconds = self.settings.sync_interval_hours * 3600
     UIManager:scheduleIn(interval_seconds, self.periodic_sync_task)
-    logger.info("OPDS: Scheduled periodic sync in", interval_seconds, "seconds")
+    logger.dbg("OPDS: Scheduled periodic sync in", interval_seconds, "seconds")
 end
 
 function OPDS:performAutoSync()
     if self.sync_in_progress then
-        logger.info("OPDS: Sync already in progress, skipping")
+        logger.dbg("OPDS: Sync already in progress, skipping")
         return
     end
-    -- Check if we have a sync directory configured
     if not self.settings.sync_dir then
-        logger.info("OPDS: No sync directory configured, skipping auto-sync")
+        logger.dbg("OPDS: No sync directory configured, skipping auto-sync")
         return
     end
 
-    -- Check if enough time has passed since last sync
     local now = os.time()
     local time_since_last = now - (self.settings.last_sync_time or 0)
     local min_interval = self.settings.sync_interval_hours * 3600
-
     if time_since_last < min_interval then
-        logger.info("OPDS: Last sync too recent, skipping")
+        logger.dbg("OPDS: Last sync too recent, skipping")
         return
     end
 
-    -- Check network connectivity
     local NetworkMgr = require("ui/network/manager")
     if not NetworkMgr:isOnline() then
-        logger.info("OPDS: Not online, skipping auto-sync")
+        logger.dbg("OPDS: Not online, skipping auto-sync")
         return
     end
 
     self.sync_in_progress = true
-    logger.info("OPDS: Starting auto-sync")
+    logger.dbg("OPDS: Starting auto-sync")
 
-    -- Create browser instance if it doesn't exist
-    if not self.opds_browser then
-        self.opds_browser = OPDSBrowser:new{
-            servers = self.servers,
-            downloads = self.downloads,
-            settings = self.settings,
-            pending_syncs = self.pending_syncs,
-            title = _("OPDS catalog"),
-            is_popout = false,
-            is_borderless = true,
-            title_bar_fm_style = true,
-            _manager = self,
-        }
-    end
-
-    if self.opds_browser then
-        self.opds_browser.sync_force = false
-        self.opds_browser:checkSyncDownload(nil, true) -- Pass true for auto_sync
-    end
-
-    self.sync_in_progress = false
+    local auto_browser = OPDSBrowser:new{
+        servers = self.servers,
+        downloads = self.downloads,
+        settings = self.settings,
+        pending_syncs = self.pending_syncs,
+        title = _("OPDS catalog"),
+        is_popout = false,
+        is_borderless = true,
+        title_bar_fm_style = true,
+        _manager = self,
+    }
+    auto_browser.sync_force = false
+    auto_browser:checkSyncDownload(nil, true, function()
+        self.sync_in_progress = false
+        logger.dbg("OPDS: Auto-sync completed")
+    end)
 end
 
 function OPDS:saveSettings()
@@ -264,6 +248,10 @@ function OPDS:saveSettings()
         self.opds_settings:flush()
         self.updated = false
     end
+end
+
+function OPDS:onFlushSettings()
+    self:saveSettings()
 end
 
 function OPDS:onCloseWidget()

--- a/opds.koplugin/opdsbrowser.lua
+++ b/opds.koplugin/opdsbrowser.lua
@@ -1869,10 +1869,10 @@ function OPDSBrowser:fillPendingSyncs(server)
     self.sync_server_list       = self.sync_server_list or {}
     self.sync_max_dl            = self.settings.sync_max_dl or 50
 
-    -- Build a set of URLs already pending to avoid duplicates
+    -- Build a URL→index map for deduplication and path updates
     local pending_urls = {}
-    for _, item in ipairs(self.pending_syncs) do
-        pending_urls[item.url] = true
+    for i, item in ipairs(self.pending_syncs) do
+        pending_urls[item.url] = i
     end
 
     local file_list
@@ -1908,9 +1908,12 @@ function OPDSBrowser:fillPendingSyncs(server)
                 local filetype = self.getFiletype(link)
                 if filetype then
                     if not file_str or file_list and file_list[filetype] then
-                        if not pending_urls[link.href] then
-                            local filename = self:getFileName(entry)
-                            local download_path = self:getLocalDownloadPath(server, filename, filetype, link.href)
+                        local filename = self:getFileName(entry)
+                        local download_path = self:getLocalDownloadPath(server, filename, filetype, link.href)
+                        if pending_urls[link.href] then
+                            -- Update file path in case sync_dir or filename settings changed
+                            self.pending_syncs[pending_urls[link.href]].file = download_path
+                        else
                             if dl_count <= self.sync_max_dl then
                                 table.insert(self.pending_syncs, {
                                     file = download_path,
@@ -1919,7 +1922,7 @@ function OPDSBrowser:fillPendingSyncs(server)
                                     password = self.root_catalog_password,
                                     catalog = server.url,
                                 })
-                                pending_urls[link.href] = true
+                                pending_urls[link.href] = #self.pending_syncs
                                 dl_count = dl_count + 1
                             end
                         end

--- a/opds.koplugin/opdsbrowser.lua
+++ b/opds.koplugin/opdsbrowser.lua
@@ -650,6 +650,27 @@ function OPDSBrowser:parseFeed(item_url)
     end
 end
 
+-- Decodes RFC 2047 MIME encoded-words that some servers wrap filenames in.
+-- e.g. =?UTF-8?Q?My=5FBook.epub?= -> "My_Book.epub"
+--      =?UTF-8?B?TXkgQm9vay5lcHVi?= -> "My Book.epub"
+local function decodeMIMEEncodedWords(str)
+    if not str or not str:find("=%?") then return str end
+    return (str:gsub("=%?([^?]+)%?([BbQq])%?([^?]*)%?=", function(_, encoding, text)
+        if encoding:upper() == "Q" then
+            text = text:gsub("_", " ")
+            text = text:gsub("=(%x%x)", function(hex)
+                return string.char(tonumber(hex, 16))
+            end)
+        elseif encoding:upper() == "B" then
+            local ok, mime = pcall(require, "mime")
+            if ok and mime.unb64 then
+                text = mime.unb64(text) or text
+            end
+        end
+        return text
+    end))
+end
+
 function OPDSBrowser:getServerFileName(item_url, filetype)
     local headers = self:fetchFeed(item_url, true)
     local filename
@@ -658,11 +679,21 @@ function OPDSBrowser:getServerFileName(item_url, filetype)
         logger.dbg("OPDSBrowser: server file headers", socketutil.redact_headers(headers))
         local disposition = headers["content-disposition"]
         if disposition then
-            -- Try to get filename inside quotes (can contain spaces)
-            filename = disposition:match('filename="([^"]+)"')
+            -- RFC 5987 filename* (preferred per RFC 6266, handles non-ASCII properly)
+            local encoded = disposition:match("[Ff]ilename%*=[Uu][Tt][Ff]%-8''([^;%s]+)")
+            if encoded then
+                filename = url.unescape(encoded)
+            end
             if not filename then
-                -- Fallback: try filename without quotes, until end or semicolon
-                filename = disposition:match('filename=([^;]+)')
+                -- Try to get filename inside quotes (can contain spaces)
+                filename = disposition:match('filename="([^"]+)"')
+                if not filename then
+                    -- Fallback: try filename without quotes, until end or semicolon
+                    filename = disposition:match('filename=([^;]+)')
+                end
+                if filename then
+                    filename = decodeMIMEEncodedWords(filename)
+                end
             end
         end
 
@@ -1282,6 +1313,7 @@ function OPDSBrowser:checkDownloadFile(local_path, remote_url, username, passwor
 end
 
 function OPDSBrowser:downloadFile(local_path, remote_url, username, password, caller_callback)
+    local temp_path = local_path .. ".download"
     logger.dbg("Downloading file", local_path, "from", remote_url)
     local code, headers, status
     local parsed = url.parse(remote_url)
@@ -1292,7 +1324,7 @@ function OPDSBrowser:downloadFile(local_path, remote_url, username, password, ca
             headers  = {
                 ["Accept-Encoding"] = "identity",
             },
-            sink     = ltn12.sink.file(io.open(local_path, "w")),
+            sink     = ltn12.sink.file(io.open(temp_path, "w")),
             user     = username,
             password = password,
         })
@@ -1303,19 +1335,20 @@ function OPDSBrowser:downloadFile(local_path, remote_url, username, password, ca
         })
     end
     if code == 200 then
+        os.rename(temp_path, local_path)
         logger.dbg("File downloaded to", local_path)
         if caller_callback then
             caller_callback(local_path)
         end
         return true
     elseif code == 302 and remote_url:match("^https") and headers.location:match("^http[^s]") then
-        util.removeFile(local_path)
+        util.removeFile(temp_path)
         UIManager:show(InfoMessage:new{
             text = T(_("Insecure HTTPS → HTTP downgrade attempted by redirect from:\n\n'%1'\n\nto\n\n'%2'.\n\nPlease inform the server administrator that many clients disallow this because it could be a downgrade attack."), BD.url(remote_url), BD.url(headers.location)),
             icon = "notice-warning",
         })
     else
-        util.removeFile(local_path)
+        util.removeFile(temp_path)
         logger.dbg("OPDSBrowser:downloadFile: Request failed:", status or code)
         logger.dbg("OPDSBrowser:downloadFile: Response headers:", headers)
         UIManager:show(InfoMessage:new {
@@ -1835,6 +1868,12 @@ function OPDSBrowser:fillPendingSyncs(server)
     self.sync_server_list       = self.sync_server_list or {}
     self.sync_max_dl            = self.settings.sync_max_dl or 50
 
+    -- Build a set of URLs already pending to avoid duplicates
+    local pending_urls = {}
+    for _, item in ipairs(self.pending_syncs) do
+        pending_urls[item.url] = true
+    end
+
     local file_list
     local file_str = self.settings.filetypes
     local new_last_download = nil
@@ -1868,17 +1907,20 @@ function OPDSBrowser:fillPendingSyncs(server)
                 local filetype = self.getFiletype(link)
                 if filetype then
                     if not file_str or file_list and file_list[filetype] then
-                        local filename = self:getFileName(entry)
-                        local download_path = self:getLocalDownloadPath(server, filename, filetype, link.href)
-                        if dl_count <= self.sync_max_dl then -- Append only max_dl entries... may still have sync backlog
-                            table.insert(self.pending_syncs, {
-                                file = download_path,
-                                url = link.href,
-                                username = self.root_catalog_username,
-                                password = self.root_catalog_password,
-                                catalog = server.url,
-                            })
-                            dl_count = dl_count + 1
+                        if not pending_urls[link.href] then
+                            local filename = self:getFileName(entry)
+                            local download_path = self:getLocalDownloadPath(server, filename, filetype, link.href)
+                            if dl_count <= self.sync_max_dl then
+                                table.insert(self.pending_syncs, {
+                                    file = download_path,
+                                    url = link.href,
+                                    username = self.root_catalog_username,
+                                    password = self.root_catalog_password,
+                                    catalog = server.url,
+                                })
+                                pending_urls[link.href] = true
+                                dl_count = dl_count + 1
+                            end
                         end
                         break
                     end
@@ -1992,21 +2034,23 @@ function OPDSBrowser:downloadPendingSyncs(auto_sync)
         local dl_size = #dl_list
         for i = dl_size, 1, -1 do
             local item = dl_list[i]
+            local temp_path = item.file .. ".download"
             if downloaded and downloaded[item.file] then
                 dl_count = dl_count + 1
                 table.remove(dl_list, i)
-            else -- if subprocess has been interrupted, check for the downloaded file
+            else
+                -- Final file exists: completed before interruption, or pre-existing (duplicate)
                 local attr = lfs.attributes(item.file)
                 if attr then
-                    if attr.size > 0 then
-                        table.remove(dl_list, i)
-                        if attr.modification > os.time() - 300 then -- Only count files touched in the last 5 mins
-                            dl_count = dl_count + 1
-                        end
-                    else -- incomplete download
-                        os.remove(item.file)
+                    table.remove(dl_list, i)
+                    if attr.modification > os.time() - 300 then
+                        dl_count = dl_count + 1
                     end
                 end
+            end
+            -- Always clean up partial downloads left by killed subprocess
+            if lfs.attributes(temp_path) then
+                os.remove(temp_path)
             end
         end
         if dl_count > 0 then

--- a/opds.koplugin/opdsbrowser.lua
+++ b/opds.koplugin/opdsbrowser.lua
@@ -168,82 +168,29 @@ function OPDSBrowser:showOPDSMenu()
     }
     UIManager:show(dialog)
 end
-function OPDSBrowser:setExcludedAuthors()
-    -- Find current server
-    local current_server = nil
+
+function OPDSBrowser:findCurrentServer()
     for _, server in ipairs(self.servers) do
         if server.title == self.root_catalog_title then
-            current_server = server
-            break
+            return server
         end
     end
-
-    if not current_server then
-        UIManager:show(InfoMessage:new{text = _("No catalog selected")})
-        return
-    end
-
-    local current_excluded = table.concat(current_server.excluded_authors or {}, ", ")
-    local dialog
-    dialog = InputDialog:new{
-        title = _("Excluded Authors"),
-        description = _("Comma-separated list of authors to exclude"),
-        input_hint = _("Author One, Author Two"),
-        input = current_excluded,
-        buttons = {
-            {
-                {
-                    text = _("Cancel"),
-                    id = "close",
-                    callback = function()
-                        UIManager:close(dialog)
-                    end,
-                },
-                {
-                    text = _("Save"),
-                    is_enter_default = true,
-                    callback = function()
-                        local input_text = dialog:getInputText()
-                        current_server.excluded_authors = {}
-                        for author in util.gsplit(input_text, ",") do
-                            table.insert(current_server.excluded_authors, util.trim(author))
-                        end
-                        self._manager.updated = true
-                        UIManager:close(dialog)
-                        if self.paths and #self.paths > 0 and self.paths[#self.paths] then
-                            self:updateCatalog(self.paths[#self.paths].url, true)
-                        end
-                    end,
-                },
-            },
-        },
-    }
-    UIManager:show(dialog)
-    dialog:onShowKeyboard()
 end
 
-function OPDSBrowser:setExcludedCategories()
-    -- Find current server
-    local current_server = nil
-    for _, server in ipairs(self.servers) do
-        if server.title == self.root_catalog_title then
-            current_server = server
-            break
-        end
-    end
-
+function OPDSBrowser:editFilterList(field_name, title, description, hint)
+    local current_server = self:findCurrentServer()
     if not current_server then
         UIManager:show(InfoMessage:new{text = _("No catalog selected")})
         return
     end
 
-    local current_excluded = table.concat(current_server.excluded_categories or {}, ", ")
+    local current_value = table.concat(current_server[field_name] or {}, ", ")
     local dialog
     dialog = InputDialog:new{
-        title = _("Excluded Categories"),
-        description = _("Comma-separated list of categories to exclude"),
-        input_hint = _("Fiction, Non-Fiction"),
-        input = current_excluded,
+        title = title,
+        description = description,
+        input_hint = hint,
+        input = current_value,
         buttons = {
             {
                 {
@@ -258,117 +205,9 @@ function OPDSBrowser:setExcludedCategories()
                     is_enter_default = true,
                     callback = function()
                         local input_text = dialog:getInputText()
-                        current_server.excluded_categories = {}
-                        for category in util.gsplit(input_text, ",") do
-                            table.insert(current_server.excluded_categories, util.trim(category))
-                        end
-                        self._manager.updated = true
-                        UIManager:close(dialog)
-                        if self.paths and #self.paths > 0 and self.paths[#self.paths] then
-                            self:updateCatalog(self.paths[#self.paths].url, true)
-                        end
-                    end,
-                },
-            },
-        },
-    }
-    UIManager:show(dialog)
-    dialog:onShowKeyboard()
-end
-
-function OPDSBrowser:setIncludedAuthors()
-    -- Find current server
-    local current_server = nil
-    for _, server in ipairs(self.servers) do
-        if server.title == self.root_catalog_title then
-            current_server = server
-            break
-        end
-    end
-
-    if not current_server then
-        UIManager:show(InfoMessage:new{text = _("No catalog selected")})
-        return
-    end
-
-    local current_included = table.concat(current_server.included_authors or {}, ", ")
-    local dialog
-    dialog = InputDialog:new{
-        title = _("Included Authors"),
-        description = _("Comma-separated list of authors to include"),
-        input_hint = _("Author One, Author Two"),
-        input = current_included,
-        buttons = {
-            {
-                {
-                    text = _("Cancel"),
-                    id = "close",
-                    callback = function()
-                        UIManager:close(dialog)
-                    end,
-                },
-                {
-                    text = _("Save"),
-                    is_enter_default = true,
-                    callback = function()
-                        local input_text = dialog:getInputText()
-                        current_server.included_authors = {}
-                        for author in util.gsplit(input_text, ",") do
-                            table.insert(current_server.included_authors, util.trim(author))
-                        end
-                        self._manager.updated = true
-                        UIManager:close(dialog)
-                        if self.paths and #self.paths > 0 and self.paths[#self.paths] then
-                            self:updateCatalog(self.paths[#self.paths].url, true)
-                        end
-                    end,
-                },
-            },
-        },
-    }
-    UIManager:show(dialog)
-    dialog:onShowKeyboard()
-end
-
-function OPDSBrowser:setIncludedCategories()
-    -- Find current server
-    local current_server = nil
-    for _, server in ipairs(self.servers) do
-        if server.title == self.root_catalog_title then
-            current_server = server
-            break
-        end
-    end
-
-    if not current_server then
-        UIManager:show(InfoMessage:new{text = _("No catalog selected")})
-        return
-    end
-
-    local current_included = table.concat(current_server.included_categories or {}, ", ")
-    local dialog
-    dialog = InputDialog:new{
-        title = _("Included Categories"),
-        description = _("Comma-separated list of categories to include"),
-        input_hint = _("Fiction, Non-Fiction"),
-        input = current_included,
-        buttons = {
-            {
-                {
-                    text = _("Cancel"),
-                    id = "close",
-                    callback = function()
-                        UIManager:close(dialog)
-                    end,
-                },
-                {
-                    text = _("Save"),
-                    is_enter_default = true,
-                    callback = function()
-                        local input_text = dialog:getInputText()
-                        current_server.included_categories = {}
-                        for category in util.gsplit(input_text, ",") do
-                            table.insert(current_server.included_categories, util.trim(category))
+                        current_server[field_name] = {}
+                        for entry in util.gsplit(input_text, ",") do
+                            table.insert(current_server[field_name], util.trim(entry))
                         end
                         self._manager.updated = true
                         UIManager:close(dialog)
@@ -402,38 +241,22 @@ function OPDSBrowser:showFacetMenu()
     table.insert(buttons, {}) -- separator
 
     -- Add filter settings
-    table.insert(buttons, {{
-        text = "\u{f0b0} " .. _("Set excluded authors"),
-        callback = function()
-            UIManager:close(dialog)
-            self:setExcludedAuthors()
-        end,
-        align = "left",
-    }})
-    table.insert(buttons, {{
-        text = "\u{f0b0} " .. _("Set excluded categories"),
-        callback = function()
-            UIManager:close(dialog)
-            self:setExcludedCategories()
-        end,
-        align = "left",
-    }})
-    table.insert(buttons, {{
-        text = "\u{f0b0} " .. _("Set included authors"),
-        callback = function()
-            UIManager:close(dialog)
-            self:setIncludedAuthors()
-        end,
-        align = "left",
-    }})
-    table.insert(buttons, {{
-        text = "\u{f0b0} " .. _("Set included categories"),
-        callback = function()
-            UIManager:close(dialog)
-            self:setIncludedCategories()
-        end,
-        align = "left",
-    }})
+    local filter_defs = {
+        { field = "excluded_authors",    title = _("Excluded Authors"),    desc = _("Comma-separated list of authors to exclude"),    hint = _("Author One, Author Two") },
+        { field = "excluded_categories", title = _("Excluded Categories"), desc = _("Comma-separated list of categories to exclude"), hint = _("Fiction, Non-Fiction") },
+        { field = "included_authors",    title = _("Included Authors"),    desc = _("Comma-separated list of authors to include"),    hint = _("Author One, Author Two") },
+        { field = "included_categories", title = _("Included Categories"), desc = _("Comma-separated list of categories to include"), hint = _("Fiction, Non-Fiction") },
+    }
+    for _, def in ipairs(filter_defs) do
+        table.insert(buttons, {{
+            text = "\u{f0b0} " .. def.title,
+            callback = function()
+                UIManager:close(dialog)
+                self:editFilterList(def.field, def.title, def.desc, def.hint)
+            end,
+            align = "left",
+        }})
+    end
     table.insert(buttons, {}) -- separator
 
     -- Add search option if available
@@ -502,10 +325,10 @@ local function buildRootEntry(server)
         url        = server.url,
         username   = server.username,
         password   = server.password,
-        raw_names  = server.raw_names, -- use server raw filenames for download
+        raw_names  = server.raw_names,
         searchable = server.url and server.url:match("%%s") and true or false,
         sync       = server.sync,
-        sync_dir   = server.sync_dir,  -- Add this line
+        sync_dir   = server.sync_dir,
         excluded_authors = server.excluded_authors,
         excluded_categories = server.excluded_categories,
         included_authors = server.included_authors,
@@ -599,7 +422,6 @@ function OPDSBrowser:addEditCatalog(item)
         },
     }
 
-    -- Existing check buttons...
     check_button_raw_names = CheckButton:new{
         text = _("Use server filenames"),
         checked = item and item.raw_names,
@@ -665,7 +487,10 @@ function OPDSBrowser:addSubCatalog(item_url)
                         if name ~= "" then
                             UIManager:close(dialog)
                             local fields = {name, item_url,
-                                self.root_catalog_username, self.root_catalog_password, self.root_catalog_raw_names}
+                                self.root_catalog_username, self.root_catalog_password,
+                                nil, nil, nil, nil, -- filter fields (5-8)
+                                self.root_catalog_raw_names, -- raw_names (9)
+                            }
                             self:editCatalogFromInput(fields, nil, true) -- no init, stay in the subcatalog
                         end
                     end,
@@ -1414,17 +1239,14 @@ function OPDSBrowser.getFiletype(link)
 end
 
 -- Returns user selected or last opened folder
-function OPDSBrowser:getCurrentDownloadDir(item)
-    -- Check if we have a per-catalog sync directory
-    if item and item.sync_dir then
-        return item.sync_dir
-    end
-    -- Fall back to global sync directory
-    if self.settings.sync_dir then
+function OPDSBrowser:getCurrentDownloadDir(server)
+    if self.sync then
+        if server and server.sync_dir then
+            return server.sync_dir
+        end
         return self.settings.sync_dir
     end
-    -- Default download directory
-    return self.download_dir
+    return G_reader_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
 end
 
 function OPDSBrowser:getLocalDownloadPath(server, filename, filetype, remote_url)
@@ -1851,8 +1673,8 @@ end
 function OPDSBrowser:setMaxSyncDownload()
     local current_max_dl = self.settings.sync_max_dl or 50
     local spin = SpinWidget:new{
-        title_text = "Set maximum sync size",
-        info_text = "Set the max number of books to download at a time",
+        title_text = _("Set maximum sync size"),
+        info_text = _("Set the max number of books to download at a time"),
         value = current_max_dl,
         value_min = 0,
         value_max = 1000,
@@ -1860,7 +1682,7 @@ function OPDSBrowser:setMaxSyncDownload()
         value_hold_step = 50,
         default_value = 50,
         wrap = true,
-        ok_text = "Save",
+        ok_text = _("Save"),
         callback = function(spin)
             self.settings.sync_max_dl = spin.value
             self._manager.updated = true
@@ -1937,66 +1759,69 @@ function OPDSBrowser:updateFieldInCatalog(item, name, value)
     self._manager.updated = true
 end
 
-function OPDSBrowser:checkSyncDownload(idx, auto_sync)
-    logger.info("OPDS: checkSyncDownload called, sync_dir =", self.settings.sync_dir)
-    if self.settings.sync_dir then
-        logger.info("OPDS: Starting sync process")
-        self.sync = true
-        local info
+function OPDSBrowser:checkSyncDownload(idx, auto_sync, completion_callback)
+    logger.dbg("OPDS: checkSyncDownload called, sync_dir =", self.settings.sync_dir)
+    if not self.settings.sync_dir then
+        logger.dbg("OPDS: No sync directory configured")
         if not auto_sync then
-            info = InfoMessage:new{
-                text = _("Synchronizing lists…"),
-            }
-            UIManager:show(info)
-            UIManager:forceRePaint()
+            UIManager:show(InfoMessage:new{
+                text = _("Please choose a folder for sync downloads first"),
+            })
         end
-        if idx then
-            self:fillPendingSyncs(self.servers[idx-1]) -- First item is "Downloads"
-        else
-            for _, item in ipairs(self.servers) do
-                if item.sync then
-                    self:fillPendingSyncs(item)
-                end
-            end
-        end
-        if not auto_sync and info then
-            UIManager:close(info)
-        end
+        if completion_callback then completion_callback() end
+        return
+    end
 
-        if #self.pending_syncs > 0 then
-            logger.info("OPDS: Found", #self.pending_syncs, "items to download")
-            Trapper:wrap(function()
-                local success, err = pcall(function()
-                    self:downloadPendingSyncs(auto_sync)
-                end)
-                if not success then
-                    logger.err("OPDS: Download failed:", err)
-                end
-                -- Always update last sync time
-                self.settings.last_sync_time = os.time()
-                self._manager.updated = true
-                self._manager:saveSettings()
-                logger.info("OPDS: Sync completed with downloads")
-            end)
-        else
-            -- Only show "Up to date!" for manual sync
-            if not auto_sync then
-                UIManager:show(InfoMessage:new{
-                    text = _("Up to date!"),
-                })
+    logger.dbg("OPDS: Starting sync process")
+    self.sync = true
+    local info
+    if not auto_sync then
+        info = InfoMessage:new{
+            text = _("Synchronizing lists…"),
+        }
+        UIManager:show(info)
+        UIManager:forceRePaint()
+    end
+    if idx then
+        self:fillPendingSyncs(self.servers[idx-1]) -- First item is "Downloads"
+    else
+        for _, item in ipairs(self.servers) do
+            if item.sync then
+                self:fillPendingSyncs(item)
             end
-            logger.info("OPDS: Sync complete - up to date")
-            -- Update last sync time even if nothing new
+        end
+    end
+    if not auto_sync and info then
+        UIManager:close(info)
+    end
+
+    if #self.pending_syncs > 0 then
+        logger.dbg("OPDS: Found", #self.pending_syncs, "items to download")
+        Trapper:wrap(function()
+            local success, err = pcall(function()
+                self:downloadPendingSyncs(auto_sync)
+            end)
+            if not success then
+                logger.err("OPDS: Download failed:", err)
+            end
             self.settings.last_sync_time = os.time()
             self._manager.updated = true
-        end
-        self.sync = false
-        logger.info("OPDS: Sync flag reset")
+            self._manager:saveSettings()
+            self.sync = false
+            logger.dbg("OPDS: Sync completed with downloads")
+            if completion_callback then completion_callback() end
+        end)
     else
-        logger.info("OPDS: No sync directory configured")
-        UIManager:show(InfoMessage:new{
-            text = _("Please choose a folder for sync downloads first"),
-        })
+        if not auto_sync then
+            UIManager:show(InfoMessage:new{
+                text = _("Up to date!"),
+            })
+        end
+        self.settings.last_sync_time = os.time()
+        self._manager.updated = true
+        self.sync = false
+        logger.dbg("OPDS: Sync complete - up to date")
+        if completion_callback then completion_callback() end
     end
 end
 
@@ -2184,13 +2009,11 @@ function OPDSBrowser:downloadPendingSyncs(auto_sync)
                 end
             end
         end
-        local duplicate_count = duplicate_list and #duplicate_list or 0
-        dl_count = dl_count - duplicate_count
         if dl_count > 0 then
             UIManager:show(Notification:new{
                 text = T(N_("1 book downloaded", "%1 books downloaded", dl_count), dl_count)
             })
-            logger.info("OPDS: Download completed -", dl_count, "books")
+            logger.dbg("OPDS: Download completed -", dl_count, "books")
         end
         self._manager.updated = true
         return duplicate_list
@@ -2200,7 +2023,7 @@ function OPDSBrowser:downloadPendingSyncs(auto_sync)
 
     if duplicate_list and #duplicate_list > 0 then
         if auto_sync then
-            logger.info("OPDS: Auto-sync - skipping", #duplicate_list, "duplicate files")
+            logger.dbg("OPDS: Auto-sync - skipping", #duplicate_list, "duplicate files")
         else
             local textviewer
             local duplicate_files = { _("These files are already on the device:") }
@@ -2259,6 +2082,6 @@ function OPDSBrowser:downloadPendingSyncs(auto_sync)
             UIManager:show(textviewer)
         end
     end
-    logger.info("OPDS: downloadPendingSyncs fully completed")
+    logger.dbg("OPDS: downloadPendingSyncs fully completed")
 end
 return OPDSBrowser

--- a/opds.koplugin/opdsbrowser.lua
+++ b/opds.koplugin/opdsbrowser.lua
@@ -436,6 +436,7 @@ function OPDSBrowser:addEditCatalog(item)
     -- Add sync directory button
     button_sync_dir = Button:new{
         text = item and item.sync_dir and _("Sync folder: ") .. item.sync_dir or _("Set sync folder"),
+        sync_dir = item and item.sync_dir,
         callback = function()
             local force_chooser_dir_for_per_catalog
             if Device:isAndroid() then


### PR DESCRIPTION
## Summary

Found several bugs while reviewing the plugin. Three are critical (will crash or corrupt data), the rest are behavioral/cleanup.

### Critical fixes
- **`addSubCatalog` field index mismatch** — when adding a sub-catalog as a bookmark, `raw_names` was placed at field index 5, but `editCatalogFromInput` expects excluded_authors at 5 and `raw_names` at 9. Every sub-catalog saved via this path had corrupted settings.
- **`getCurrentDownloadDir` returns nil for manual downloads** — the fallback to `G_reader_settings` was removed, replaced by `self.download_dir` which is never defined. Also, manual downloads were wrongly redirected to `sync_dir` when one was configured.
- **Missing `onFlushSettings` lifecycle handler** — the framework event `onFlushSettings` (called on sleep/shutdown) was replaced by `saveSettings()` which the framework never calls. Settings could be lost.

### Behavioral fixes
- **`sync_in_progress` guard is ineffective** — `Trapper:wrap()` returns immediately, so the flag was always reset before sync actually completed. Now uses a completion callback.
- **Phantom `OPDSBrowser` widget in `performAutoSync`** — a full Menu widget was created and stored in `self.opds_browser` but never shown or cleaned up. Now uses a local variable.

### Cleanup
- Refactored 4 near-identical filter functions (`setExcludedAuthors`, `setExcludedCategories`, `setIncludedAuthors`, `setIncludedCategories`) into a single `editFilterList(field_name, title, desc, hint)` — ~150 fewer lines
- Wrapped untranslated strings in `setMaxSyncDownload` with `_()`
- Demoted routine `logger.info` calls to `logger.dbg`
- Fixed `dl_count` subtraction in `downloadPendingSyncs` (duplicate count was subtracted from downloaded count, could go negative)
- Removed narrating comments

## Test plan
- [x] Add/edit a catalog with filters and per-catalog sync dir — verify settings persist after restart
- [x] Add a sub-catalog as bookmark — verify raw_names and sync settings are correct
- [x] Manual download (no sync_dir set) — verify it uses the default download directory
- [x] Sync with per-catalog sync_dir — verify files go to the right folder
- [x] Toggle auto-sync on/off — verify periodic sync schedules/unschedules
- [x] Sleep and resume device — verify settings are not lost